### PR TITLE
feat: add dkoverlay, ltoverlay and nooverlay attributes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -195,6 +195,66 @@
         </template>
       </demo-snippet>
 
+      <!-- -->
+
+      <h2>auro-dialog dkoverlay example</h2>
+      <demo-snippet>
+        <template>
+          <button onclick="fireDemo('#dialogDkOverlay');">Default Dialog w/ Dark Overlay</button>
+
+          <auro-dialog id="dialogDkOverlay" dkoverlay>
+            <span slot="header">Dialog w/footer</span>
+            <span slot="content">
+              <long-text count="500"></long-text>
+            </span>
+
+            <span slot="footer">
+              <button onclick="closeDemo('#dialogDkOverlay');">Close</button>
+            </span>
+          </auro-dialog>
+          </template>
+      </demo-snippet>
+
+      <!-- -->
+
+      <h2>auro-dialog ltoverlay example</h2>
+      <demo-snippet>
+        <template>
+          <button onclick="fireDemo('#dialogLtOverlay');">Default Dialog w/ Light Overlay</button>
+
+          <auro-dialog id="dialogLtOverlay" ltoverlay>
+            <span slot="header">Dialog w/footer</span>
+            <span slot="content">
+              <long-text count="500"></long-text>
+            </span>
+
+            <span slot="footer">
+              <button onclick="closeDemo('#dialogLtOverlay');">Close</button>
+            </span>
+          </auro-dialog>
+        </template>
+      </demo-snippet>
+
+      <!-- -->
+
+      <h2>auro-dialog nooverlay example</h2>
+      <demo-snippet>
+        <template>
+          <button onclick="fireDemo('#dialogNoOverlay');">Default Dialog w/ No Overlay</button>
+
+          <auro-dialog id="dialogNoOverlay" nooverlay>
+            <span slot="header">Dialog w/footer</span>
+            <span slot="content">
+              <long-text count="500"></long-text>
+            </span>
+
+            <span slot="footer">
+              <button onclick="closeDemo('#dialogNoOverlay');">Close</button>
+            </span>
+          </auro-dialog>
+        </template>
+      </demo-snippet>
+
 
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,10 +4,13 @@ auro-dialog appear above the page and require the user's attention.
 
 ## Attributes
 
-| Attribute | Type      | Description                     |
-|-----------|-----------|---------------------------------|
-| `md`      | `Boolean` | Sets dialog box to medium style |
-| `sm`      | `Boolean` | Sets dialog box to small style  |
+| Attribute   | Type      | Description                            |
+|-------------|-----------|----------------------------------------|
+| `dkoverlay` | `Boolean` | Sets the dialog overlay to dark style  |
+| `ltoverlay` | `Boolean` | Sets the dialog overlay to light style |
+| `md`        | `Boolean` | Sets dialog box to medium style        |
+| `nooverlay` | `Boolean` | Disables the dialog overlay            |
+| `sm`        | `Boolean` | Sets dialog box to small style         |
 
 ## Properties
 

--- a/src/auro-dialog.js
+++ b/src/auro-dialog.js
@@ -18,6 +18,9 @@ import closeIcon from '@alaskaairux/orion-icons/dist/icons/close-lg_es6.js';
  * @attr {Boolean} modal - Modal dialog restricts the user to take an action (no default close actions)
  * @attr {Boolean} sm - Sets dialog box to small style
  * @attr {Boolean} md - Sets dialog box to medium style
+ * @attr {Boolean} dkoverlay - Sets the dialog overlay to dark style
+ * @attr {Boolean} ltoverlay - Sets the dialog overlay to light style
+ * @attr {Boolean} nooverlay - Disables the dialog overlay
  * @attr {Boolean} open - Sets state of dialog to open
  * @slot header - Text to display as the header of the modal
  * @slot content - Injects content into the body of the modal

--- a/src/style.scss
+++ b/src/style.scss
@@ -50,6 +50,30 @@ $auro-spacing-options: none;
   }
 }
 
+:host([dkOverlay]) {
+  .dialogOverlay {
+    &--open, &--modal {
+      background: rgba(0, 0, 0, 0.5);
+    }
+  }
+}
+
+:host([ltOverlay]) {
+  .dialogOverlay {
+    &--open, &--modal {
+      background: rgba(0, 0, 0, 0.2);
+    }
+  }
+}
+
+:host([noOverlay]) {
+  .dialogOverlay {
+    &--open, &--modal {
+      display: none;
+    }
+  }
+}
+
 :host([sm]) {
   .dialog {
     max-height: 30%;


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #12 
## Summary:

Updates dialog overlay opacity to support dkoverlay, ltoverlay, nooverlay settings. Default for default dialog state is ltoverlay. Default for modal/blocking state is dkoverlay.

## Type of change:

- [x] New capability
- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team