### PR TITLE
fix: restricts overlay clicks unless modal is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-dialog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-dialog.js
+++ b/src/auro-dialog.js
@@ -79,6 +79,17 @@ class AuroDialog extends LitElement {
   }
 
   /**
+   * @private function for allowing the overlay to be clickable when the modal is open
+   * @param {object} evt - Accepts event
+   * @returns {null}
+   */
+  toggleOverlayViewable(evt) {
+    if(this.open) {
+      this.toggleViewable(evt)
+    }
+  }
+
+  /**
    * @private function for the purpose of determining open/close state of modal and locking page scroll when dialog is open
    * @param {object} evt - Accepts event
    * @returns {boolean} - Returns open state
@@ -139,7 +150,7 @@ class AuroDialog extends LitElement {
 
 
     return html`
-      <div class="${classMap(classes)}" id="dialog-overlay" @click=${this.modal ? null : this.toggleViewable}>
+      <div class="${classMap(classes)}" id="dialog-overlay" @click=${this.modal ? null : this.toggleOverlayViewable}>
       </div>
 
       <dialog id="dialog" @click=${this.display()} class="${classMap(contentClasses)}" aria-labelledby="dialog-header">

--- a/src/auro-dialog.js
+++ b/src/auro-dialog.js
@@ -81,10 +81,10 @@ class AuroDialog extends LitElement {
   /**
    * @private function for allowing the overlay to be clickable when the modal is open
    * @param {object} evt - Accepts event
-   * @returns {null}
+   * @returns {void}
    */
   toggleOverlayViewable(evt) {
-    if(this.open) {
+    if (this.open) {
       this.toggleViewable(evt)
     }
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

In legacy placements, like AScom, clicking the gutter resulted in the Dialog opening due to the overlay in 'closed' state still being clickable, thus firing toggleVIsible.

**Fixes:** # (issue, if applicable)

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
