### PR TITLE
refactor: update opening/closing styles to use bottom positioning instead of translate

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -63,7 +63,7 @@ $auro-spacing-options: none;
   position: fixed;
   z-index: -1;
   right: 0;
-  bottom: 0;
+  bottom: -100%;
   left: 0;
   display: flex;
   flex-direction: column;
@@ -73,8 +73,6 @@ $auro-spacing-options: none;
   width: calc(100% - var(--insetPaddingXl) - var(--insetPaddingXl));
   max-height: 90%;
   padding: var(--insetPaddingXl);
-
-  transform: translateY(100%);
 
   opacity: 0;
   border: 0;
@@ -86,16 +84,24 @@ $auro-spacing-options: none;
   @include auro_grid-breakpoint--md {
     top: 10%;
     bottom: unset;
-
+    left: 0;
+    right: 0;
+    
     max-width: 80%;
     max-height: 80%;
     margin: auto;
     padding: var(--insetPaddingXxxl);
-
-    transform: scale(0);
+    
+    opacity: 0;
+    width: 0;
+    height: 0;
+    overflow: hidden;
 
     &--open {
-      transform: scale(1);
+      opacity: 1;
+      width: calc(100% - var(--insetPaddingXxxl) - var(--insetPaddingXxxl));
+      height: auto;
+      overflow: visible;
     }
   }
 
@@ -106,11 +112,8 @@ $auro-spacing-options: none;
   // open modifier
   &--open {
     z-index: var(--ds-depth-modal, $ds-depth-modal);
-
     visibility: visible;
-
-    transform: translateY(0%);
-
+    bottom: 0;
     opacity: 1;
   }
 

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -6,8 +6,12 @@ describe('auro-dialog', () => {
   it('auro-dialog is accessible', async () => {
     const el = await fixture(html`
       <auro-dialog open="true">
+        
         <span slot="header">Blocking dialog</span>
-        <span slot="content">Hello World!</span>
+        <span slot="content">
+          Hello World!
+          <button>Test Button</button>
+        </span>
         <span slot="footer"><button>Click</button></span>
       </auro-dialog>
     `);


### PR DESCRIPTION
refactor: update opening/closing styles to use bottom positioning instead of translate

This is to support dynamic layouts, since `transform` creates a new positioning boundary, we need this component to be transparent in regards to positioning to allow for children to be positioned however they need.

1. Removed translate
2. Used bottom positioning instead

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Refactor opening and closing styles to use bottom positioning and opacity instead of transform-based animations, and update SCSS imports to the new design-tokens path.

Enhancements:
- Migrate SCSS imports for design tokens to the updated tokens directory
- Remove translateY and scale transforms and replace with bottom positioning and opacity adjustments for open/close states
- Revise responsive breakpoint styles to control width, height, and overflow rather than using scale transforms