### PR TITLE
fix: remove bottom position on bigger screen

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -65,6 +65,7 @@ $auro-spacing-options: none;
   right: 0;
   bottom: -100%;
   left: 0;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   visibility: hidden;
@@ -76,6 +77,14 @@ $auro-spacing-options: none;
 
   opacity: 0;
   border: 0;
+
+  // open modifier
+  &--open {
+    z-index: var(--ds-depth-modal, $ds-depth-modal);
+    visibility: visible;
+    bottom: 0;
+    opacity: 1;
+  }
 
   // baseline dialog UI / mobile-first
   @include auro_transition(all, 0.3s, ease-in-out);
@@ -107,14 +116,6 @@ $auro-spacing-options: none;
 
   @include auro_grid-breakpoint--lg {
     max-width: 986px;
-  }
-
-  // open modifier
-  &--open {
-    z-index: var(--ds-depth-modal, $ds-depth-modal);
-    visibility: visible;
-    bottom: 0;
-    opacity: 1;
   }
 
   // footer slot
@@ -161,10 +162,12 @@ $auro-spacing-options: none;
   .dialog-header--action {
     position: absolute;
     top: var(--ds-size-400, $ds-size-400);
+    bottom: unset;
     right: var(--ds-size-400, $ds-size-400);
 
     @include auro_grid-breakpoint--md {
       top: var(--ds-size-800, $ds-size-800);
+      bottom: unset;
       right: var(--ds-size-800, $ds-size-800);
     }
   }
@@ -178,7 +181,7 @@ $auro-spacing-options: none;
   @include auro_grid-breakpoint--md {
     .dialog {
       top: 10%;
-
+      bottom: unset;
       max-width: 40%;
       max-height: 80%;
       padding: var(--insetPaddingXxl);
@@ -199,6 +202,7 @@ $auro-spacing-options: none;
   @include auro_grid-breakpoint--md {
     .dialog {
       top: 10%;
+      bottom: unset;
 
       max-width: 70%;
       max-height: 80%;
@@ -207,6 +211,7 @@ $auro-spacing-options: none;
   @include auro_grid-breakpoint--lg {
     .dialog {
       top: 10%;
+      bottom: unset;
 
       max-width: 986px;
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #58 

Unset bottom position when it's on a bigger breakpoint screen. 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix dialog component layout by removing bottom positioning on larger breakpoints, enforcing consistent box-sizing, and consolidating open state styles

Bug Fixes:
- Remove bottom property on dialog for medium and large breakpoints to prevent it from sticking to the bottom
- Unset bottom on dialog-header--action for default and medium breakpoints to correct header positioning

Enhancements:
- Add box-sizing: border-box to the dialog container
- Consolidate and relocate the –open modifier block into a single definition