### PR TITLE
fix: disable pointer-events on overlay when dialog is not open #66

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -41,9 +41,13 @@ $auro-spacing-options: none;
   width: 100%;
   height: 100%;
 
+  pointer-events: none;
+
   // Open modifier for default dialog state
   &--open {
     z-index: var(--ds-depth-overlay);
+
+    pointer-events: unset;
 
     transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 0);
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #66 

### Problem
Overlay covers the entire page when auro-dialog has its own z-index.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Disable pointer-events on the overlay when the dialog is not open to prevent it from capturing clicks