### PR TITLE
fix: add room on content area for focus-indicator #76 #75

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -5,7 +5,7 @@
 
 /* stylelint-disable at-rule-empty-line-before, custom-property-pattern, declaration-empty-line-before, order/properties-order, color-function-notation, max-nesting-depth,
    selector-class-pattern, scss/selector-no-redundant-nesting-selector, declaration-block-no-duplicate-properties, scss/double-slash-comment-empty-line-before,
-   scss/selector-nest-combinators, rule-empty-line-before,  no-descending-specificity, no-duplicate-selectors */
+   scss/selector-nest-combinators, rule-empty-line-before,  no-descending-specificity, no-duplicate-selectors, selector-max-class */
 
 // Import Auro tokens
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
@@ -138,6 +138,7 @@ $auro-spacing-options: none;
   align-items: flex-start;
   justify-content: space-between;
   padding-top: var(--ds-size-800, vac.$ds-size-800);
+  margin-bottom: var(--ds-size-300, vac.$ds-size-300);
 
   &--action {
     margin: 0;
@@ -147,12 +148,19 @@ $auro-spacing-options: none;
       cursor: pointer;
     }
   }
+
+  .heading {
+    flex: 1;
+    margin-block: 0;
+  }
 }
 
 .dialog-content {
   flex: 1;
   overflow: auto;
   overscroll-behavior: contain;
+  margin: calc(-1 * var(--ds-size-100));
+  padding: var(--ds-size-100);
 }
 
 ::slotted([slot="content"]) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #75 #76 

- add some room to prevent random scrollbar and for a focus-indicating box
- adjust margin on heading to match to the design

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add spacing around dialog header and content area to prevent unexpected scrollbar and ensure focus indicators are fully visible, and adjust heading margins to match the design.

Bug Fixes:
- Prevent random scrollbar and clipped focus indicator in dialog by adding bottom margin to the header section
- Add negative margin and padding to dialog content to provide room for focus outlines without overflow

Enhancements:
- Reset heading margins and allow the heading element to flex-grow to match the design spacing