### PR TITLE
feat: add `appearance` deprecated `ondark` #81

### DIFF
--- a/apiExamples/accessibility.html
+++ b/apiExamples/accessibility.html
@@ -2,7 +2,7 @@
   <auro-button id="openAccessibility">Unformatted Medium Dialog</auro-button>
 </div>
 
-<auro-dialog id="unformattedMdDialog" unformatted md lg ondark>
+<auro-dialog id="unformattedMdDialog" unformatted md lg close-button-appearance="inverse">
   <span slot="content">
     <img style="display: block; width: 100%" src="https://blog.alaskaair.com/wp-content/uploads/2020/11/111-psp-blog-img-guide.jpg" alt="alaska airlines pride lights" />
     <div class="unformattedWrapper">

--- a/apiExamples/decoupled.html
+++ b/apiExamples/decoupled.html
@@ -19,7 +19,7 @@
   <div slot="footer">
     <auro-button id="closeSmLg">
       I understand
-      <auro-icon category="interface" name="check-lg" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="check-lg" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>
@@ -40,7 +40,7 @@
   <div slot="footer">
     <auro-button id="closeMdLg">
       I understand
-      <auro-icon category="interface" name="check-lg" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="check-lg" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>

--- a/apiExamples/modal.html
+++ b/apiExamples/modal.html
@@ -19,7 +19,7 @@
   </div>
   <div slot="footer">
     <auro-button id="closeDefaultModal">I understand
-      <auro-icon category="interface" name="chevron-right" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="chevron-right" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>
@@ -39,7 +39,7 @@
   </div>
   <div slot="footer">
     <auro-button id="closeMediumModal">I understand
-      <auro-icon category="interface" name="chevron-right" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="chevron-right" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>
@@ -59,7 +59,7 @@
   </div>
   <div slot="footer">
     <auro-button id="closeSmallModal">I understand
-      <auro-icon category="interface" name="chevron-right" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="chevron-right" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>

--- a/apiExamples/popoverAndDropdown.html
+++ b/apiExamples/popoverAndDropdown.html
@@ -40,7 +40,7 @@
   <div slot="footer">
     <auro-button id="closePopAndDrop">
       I understand
-      <auro-icon category="interface" name="check-lg" emphasis onDark></auro-icon>
+      <auro-icon category="interface" name="check-lg" emphasis appearance="inverse"></auro-icon>
     </auro-button>
   </div>
 </auro-dialog>

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,17 +7,18 @@ The auro-dialog appears above the page and requires the user's attention.
 | Attribute | Type      | Description                                      |
 |-----------|-----------|--------------------------------------------------|
 | `md`      | `Boolean` | Sets dialog box to medium style. Adding both md and lg will set the dialog to md for desktop and lg for mobile. |
-| `onDark`  | `Boolean` | Sets close icon to white for dark backgrounds    |
+| `onDark`  | `Boolean` | DEPRECATED - use `close-button-appearance="inverse" instead. |
 | `sm`      | `Boolean` | Sets dialog box to small style. Adding both sm and lg will set the dialog to sm for desktop and lg for mobile. |
 
 ## Properties
 
-| Property         | Attribute     | Type          | Default | Description                                      |
-|------------------|---------------|---------------|---------|--------------------------------------------------|
-| `modal`          | `modal`       | `Boolean`     | false   | Modal dialog restricts the user to take an action (no default close actions) |
-| `open`           | `open`        | `Boolean`     |         | Sets state of dialog to open                     |
-| `triggerElement` |               | `HTMLElement` |         | The element to focus when the dialog is closed. If not set, defaults to the value of document.activeElement when the dialog is opened. |
-| `unformatted`    | `unformatted` | `Boolean`     | false   | Unformatted dialog window, edge-to-edge fill for content |
+| Property                | Attribute                 | Type          | Default     | Description                                      |
+|-------------------------|---------------------------|---------------|-------------|--------------------------------------------------|
+| `closeButtonAppearance` | `close-button-appearance` | `string`      | "'default'" | Defines whether the close button should be light colored for use on dark backgrounds. |
+| `modal`                 | `modal`                   | `Boolean`     | false       | Modal dialog restricts the user to take an action (no default close actions) |
+| `open`                  | `open`                    | `Boolean`     |             | Sets state of dialog to open                     |
+| `triggerElement`        |                           | `HTMLElement` |             | The element to focus when the dialog is closed. If not set, defaults to the value of document.activeElement when the dialog is opened. |
+| `unformatted`           | `unformatted`             | `Boolean`     | false       | Unformatted dialog window, edge-to-edge fill for content |
 
 ## Events
 

--- a/src/componentBase.js
+++ b/src/componentBase.js
@@ -33,7 +33,7 @@ const ESCAPE_KEYCODE = 27;
  * @attr {Boolean} unformatted - Unformatted dialog window, edge-to-edge fill for content
  * @attr {Boolean} sm - Sets dialog box to small style. Adding both sm and lg will set the dialog to sm for desktop and lg for mobile.
  * @attr {Boolean} md - Sets dialog box to medium style. Adding both md and lg will set the dialog to md for desktop and lg for mobile.
- * @attr {Boolean} onDark - Sets close icon to white for dark backgrounds
+ * @attr {Boolean} onDark - DEPRECATED - use `close-button-appearance="inverse" instead.
  * @attr {Boolean} open - Sets state of dialog to open
  * @prop {HTMLElement} triggerElement - The element to focus when the dialog is closed. If not set, defaults to the value of document.activeElement when the dialog is opened.
  * @slot header - Text to display as the header of the modal
@@ -56,6 +56,7 @@ export default class ComponentBase extends LitElement {
 
     this.modal = false;
     this.unformatted = false;
+    this.closeButtonAppearance = 'default';
 
     const versioning = new AuroDependencyVersioning();
 
@@ -81,6 +82,18 @@ export default class ComponentBase extends LitElement {
 
   static get properties() {
     return {
+
+      /**
+       * Defines whether the close button should be light colored for use on dark backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      closeButtonAppearance: {
+        type: String,
+        attribute: 'close-button-appearance',
+        reflect: true
+      },
+
       modal: { type: Boolean },
       unformatted: {
         type: Boolean,
@@ -263,7 +276,7 @@ getCloseButton() {
         variant="ghost"
         shape="circle"
         size="sm"
-        ?onDark=${this.hasAttribute("onDark")}
+        appearance=${this.hasAttribute("ondark") ? 'inverse' : this.closeButtonAppearance}
         class="dialog-header--action"
         id="dialog-close"
         @click="${this.handleCloseButtonClick}"


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #81 

This is to replace `onDark` attr with `surface` attr. 
- Adding `surface` with its default value `light`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `surface="dark"` in all examples 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a new `appearance` attribute to replace the deprecated `onDark` flag, update component logic and documentation accordingly, and bump related package versions.

New Features:
- Add `appearance` attribute with default value `default` and reflect it to replace `onDark`

Enhancements:
- Mark `onDark` attribute as deprecated in code and API table
- Update component rendering to use `appearance="inverse"` instead of `onDark`

Build:
- Bump `@aurodesignsystem/auro-button` to v12.1.0 and `@aurodesignsystem/auro-icon` to v9.1.0

Documentation:
- Revise API documentation to include `appearance` property and deprecate `onDark`
- Replace `onDark` usage with `appearance="inverse"` in all example files