### PR TITLE
perf: bind open to isPopover

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=22"
+    "node": "^22.14.0 || >=24.10.0"
   },
   "dependencies": {
     "lit": "^3.3.1"

--- a/src/componentBase.js
+++ b/src/componentBase.js
@@ -171,11 +171,7 @@ export default class ComponentBase extends LitElement {
   }
 
   set open(value) {
-    if (value) {
-      this.show();
-    } else {
-      this.hide();
-    }
+    this.isPopoverVisible = Boolean(value);
   }
 
   /**
@@ -273,6 +269,10 @@ export default class ComponentBase extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    if (this._hidePopoverTimerId) {
+      clearTimeout(this._hidePopoverTimerId);
+      this._hidePopoverTimerId = undefined;
+    }
     this.floater.disconnect();
   }
 

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -322,6 +322,21 @@ describe("auro-dialog", () => {
     expect(closeBtn.getAttribute("appearance")).to.equal("inverse");
   });
 
+  it("setting open = true before firstUpdated does not throw", async () => {
+    const el = document.createElement("auro-dialog");
+    customElements.upgrade(el);
+    // Append to DOM — LitElement schedules its first update as a microtask,
+    // so firstUpdated() has not yet run and this.dialog is still undefined.
+    document.body.appendChild(el);
+    // Must not throw even though this.dialog is uninitialized.
+    expect(() => { el.open = true; }).to.not.throw();
+    await el.updateComplete;
+    expect(el.open).to.be.true;
+    el.hide();
+    await el.updateComplete;
+    document.body.removeChild(el);
+  });
+
   it("setting open = true opens the dialog", async () => {
     const el = await fixture(html`<auro-dialog></auro-dialog>`);
     expect(el.open).to.be.false;


### PR DESCRIPTION
# Alaska Airlines Pull Request

addressing code review feedback on https://github.com/AlaskaAirlines/auro-dialog/pull/105

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-dialog/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Align dialog open state with internal popover visibility and improve lifecycle safety.

Bug Fixes:
- Prevent errors when setting the dialog open property before firstUpdated initializes internal dialog state.

Enhancements:
- Bind the open property directly to the internal isPopoverVisible flag instead of immediately invoking show/hide.
- Ensure any pending hide popover timers are cleared when the component disconnects from the DOM.

Tests:
- Add a regression test confirming that setting open = true before firstUpdated does not throw and correctly updates the open state.