### PR TITLE
fix: ensure auro-dialog focus trap activates without transition

### DIFF
--- a/docs/post-mortem/1543191.md
+++ b/docs/post-mortem/1543191.md
@@ -1,0 +1,86 @@
+# AB#1543191 — Accessibility Bug: Trap Focus in `auro-dialog` When Opened Without a Transition
+
+**Scope:** 2 files changed — `src/componentBase.js` (focus trap fallback logic) and `test/auro-dialog.test.js` (7 new tests, viewport-dual suite). No visual or API changes.
+
+---
+
+### Section 1 — The Problem
+
+`auro-dialog` relies on the `transitionend` event on the `.dialog` wrapper div to know when the open animation is complete, at which point it calls `focusTrap.focusFirstElement()` to move keyboard focus into the dialog and engage the focus trap.
+
+When a dialog is dynamically created and inserted into the DOM already in the `open` state — the pattern used by the flight-search refundable-upsell modal and the food-preorder site — no CSS `closed → open` transition occurs. The `--open` class is present from the very first render paint; the browser has nothing to transition from. Because no transition fires, `transitionend` never dispatches, `focusFirstElement()` is never called, and the focus trap never activates.
+
+The result: the dialog appears visually correct but keyboard and screen-reader users can Tab through the page content behind the dialog as if the dialog were not there. For an AT user, this is a silent failure — the UI changed but nothing announced it and focus did not move.
+
+The same no-transition path is triggered by:
+- Reduced-motion user preferences (`prefers-reduced-motion: reduce`)
+- An interrupted or cancelled CSS transition
+- Any render where `isPopoverVisible` is `true` from the initial paint
+
+---
+
+### Section 2 — Root Cause (Code-Level)
+
+In `src/componentBase.js`:
+
+- `openDialog()` (L283) creates `new FocusTrap(this.dialog)` but does not call `focusFirstElement()` immediately. A comment defers this to the `transitionend` handler.
+- `onDialogTransitionEnd()` (L305) is bound via Lit's `@transitionend` on the `.dialog` wrapper div (render template). It is the sole call site for `focusTrap.focusFirstElement()`.
+- The CSS transition (`style.scss` L122: `opacity 0.3s, visibility 0.3s, bottom 0.3s`) fires only when the `--open` class changes from absent to present. For a dialog mounted with `open=true`, the class is present from paint 1 — the transition condition is never met.
+
+---
+
+### Section 3 — The Fix
+
+A **fallback timer** was added to `openDialog()`. After creating the `FocusTrap`, a 350ms `setTimeout` is started (300ms transition duration + 50ms buffer). If `transitionend` fires first, the timer is cancelled and `focusFirstElement()` runs via the existing `onDialogTransitionEnd()` path. If `transitionend` never fires, the fallback calls `focusFirstElement()` directly.
+
+A `_focusTrapActivated` guard flag prevents double-focus in the case where both paths fire (e.g., a transition that starts late and the fallback fires first). Whichever path runs first sets the flag; the second path is a no-op.
+
+The fallback timer is also cleared in `closeDialog()` and `disconnectedCallback()` to prevent post-close or post-disconnect focus calls.
+
+**Files changed:**
+
+- `src/componentBase.js` — `openDialog()`, `onDialogTransitionEnd()`, `closeDialog()`, `disconnectedCallback()`
+
+---
+
+### Section 4 — Test Coverage
+
+The existing test suite had no coverage for the no-transition open path. Seven new tests were added, and the test suite was restructured to run twice — once at a desktop viewport (900×800) and once at a mobile viewport (300×800) — matching the `auro-drawer` dual-suite pattern.
+
+**New tests (run in both viewports):**
+
+1. `moves focus into dialog after the open transition fires` — normal path via natural `transitionend`
+2. `moves focus into dialog when mounted already-open (no transitionend fires)` — the bug scenario via fallback timer
+3. `moves focus into a dynamically-created dialog that is already open` — the exact consumer pattern (create element, set `open`, append)
+4. `does not double-focus when transitionend fires before the fallback timer` — guard flag correctness
+5. `Tab key keeps focus within the open dialog` — real `sendKeys({ press: "Tab" })` against an already-open dialog
+6. `Shift+Tab keeps focus within the open dialog` — real `sendKeys` Shift+Tab
+7. `focus is trapped in a dynamically-created already-open dialog when Tab is pressed (AB#1543191)` — explicit regression test combining dynamic creation + keyboard Tab cycling
+
+`@web/test-runner-commands` `setViewport` and `sendKeys` were added as imports to enable viewport control and real keyboard event dispatch.
+
+---
+
+### Section 5 — Risk Assessment
+
+**Identified risks from the ticket, and how each was addressed:**
+
+| Risk | Mitigation |
+|---|---|
+| Double-focus when transition fires normally | `_focusTrapActivated` guard flag; `onDialogTransitionEnd` cancels the fallback timer and sets the flag first |
+| Focus too early (before dialog is visible) | 350ms delay is longer than the 300ms CSS transition; focus cannot land before the animation is visible |
+| Reduced-motion path | No-transition path; covered by the same fallback timer code path |
+| Dynamically created/recreated dialogs | Tested explicitly with `document.createElement` + append pattern |
+| Focus restoration on close regressed | Existing "restores focus to the element that was active when the dialog opened" test continues to pass |
+
+---
+
+### Key Lessons
+
+1. **Relying solely on `transitionend` for post-open lifecycle work is fragile.** CSS transitions only fire when there is a style change to animate. Any render where the animated class is already present from paint 1 — dynamic insertion already-open, initial render with `open=true`, reduced motion — silently skips the handler. Pair `transitionend` with a timer fallback that runs when the event does not fire.
+
+2. **Accessibility failures from focus trap gaps are silent.** The dialog renders visually correctly. There is no console error, no thrown exception, no visible difference. The failure is only observable to keyboard and AT users. Silent accessibility failures require explicit test coverage to catch regressions.
+
+3. **Test the exact consumer pattern, not just the component API.** The bug only surfaces when the element is dynamically created and appended already-open — a valid DOM usage that the component must support. A test using `fixture(html\`<auro-dialog open>\`)` alone is insufficient; the test must also exercise `document.createElement` + `setAttribute('open')` + `appendChild` to cover the dynamic-insertion path.
+
+4. **`sendKeys` from `@web/test-runner-commands` enables real keyboard interaction tests in WTR.** Synthetic `KeyboardEvent` dispatches do not trigger browser-level Tab focus management or FocusTrap interception. `sendKeys` dispatches through the browser's actual input pipeline and is required to verify that Tab and Shift+Tab are genuinely trapped within the dialog.

--- a/docs/post-mortem/1543191.md
+++ b/docs/post-mortem/1543191.md
@@ -1,6 +1,10 @@
 # AB#1543191 — Accessibility Bug: Trap Focus in `auro-dialog` When Opened Without a Transition
 
-**Scope:** 2 files changed — `src/componentBase.js` (focus trap fallback logic) and `test/auro-dialog.test.js` (7 new tests, viewport-dual suite). No visual or API changes.
+**Scope:** 5 files changed — `src/componentBase.js` (focus trap fallback + disconnectedCallback teardown), `test/auro-dialog.test.js` (11 new tests, viewport-dual suite), `package.json` / `package-lock.json` (dependency bumps), `docs/post-mortem/1543191.md`. No visual or API changes.
+
+## Executive Summary
+
+`auro-dialog` focus trap silently skipped for dialogs mounted already-open because `transitionend` never fires when there is no CSS transition to animate. Added a 350ms fallback timer so focus is always captured regardless of transition presence. Fixed a secondary listener-leak where `disconnectedCallback` did not call `focusTrap.disconnect()`, allowing stale `keydown` listeners to accumulate on remount.
 
 ---
 
@@ -37,15 +41,19 @@ A `_focusTrapActivated` guard flag prevents double-focus in the case where both 
 
 The fallback timer is also cleared in `closeDialog()` and `disconnectedCallback()` to prevent post-close or post-disconnect focus calls.
 
+A secondary bug was also fixed: `disconnectedCallback()` previously did not call `focusTrap.disconnect()`, leaving the `keydown` listener attached to `this.dialog`. On remount, `openDialog()` creates a new `FocusTrap` (adding a second listener), so listeners accumulate across each mount/unmount cycle. The fix calls `focusTrap.disconnect()` in `disconnectedCallback()` alongside the timer cleanup.
+
 **Files changed:**
 
 - `src/componentBase.js` — `openDialog()`, `onDialogTransitionEnd()`, `closeDialog()`, `disconnectedCallback()`
+- `test/auro-dialog.test.js` — 11 new tests, dual-viewport suite
+- `package.json` / `package-lock.json` — `auro-library` ^5.13.3, `design-tokens` ^9.3.2, `webcorestylesheets` ^11.1.3
 
 ---
 
 ### Section 4 — Test Coverage
 
-The existing test suite had no coverage for the no-transition open path. Seven new tests were added, and the test suite was restructured to run twice — once at a desktop viewport (900×800) and once at a mobile viewport (300×800) — matching the `auro-drawer` dual-suite pattern.
+The existing test suite had no coverage for the no-transition open path. Eleven new tests were added, and the test suite was restructured to run twice — once at a desktop viewport (900×800) and once at a mobile viewport (300×800) — matching the `auro-drawer` dual-suite pattern.
 
 **New tests (run in both viewports):**
 
@@ -56,6 +64,10 @@ The existing test suite had no coverage for the no-transition open path. Seven n
 5. `Tab key keeps focus within the open dialog` — real `sendKeys({ press: "Tab" })` against an already-open dialog
 6. `Shift+Tab keeps focus within the open dialog` — real `sendKeys` Shift+Tab
 7. `focus is trapped in a dynamically-created already-open dialog when Tab is pressed (AB#1543191)` — explicit regression test combining dynamic creation + keyboard Tab cycling
+8. `cancels the fallback timer when dialog is closed before 350ms elapses` — verifies close-during-pending-timer race condition
+9. `disconnectedCallback clears the fallback timer while dialog is open` — verifies timer, focusTrap reference, and `_focusTrapActivated` are all cleaned up on disconnect
+10. `modal dialog does not close when Escape keydown is dispatched (AB#1613688)` — verifies the library-level Escape suppression for modal dialogs
+11. `rapid re-open disconnects the previous focusTrap before creating a new one` — verifies the rapid re-open guard; the old focusTrap must be disconnected before a new one is created
 
 `@web/test-runner-commands` `setViewport` and `sendKeys` were added as imports to enable viewport control and real keyboard event dispatch.
 
@@ -72,6 +84,7 @@ The existing test suite had no coverage for the no-transition open path. Seven n
 | Reduced-motion path | No-transition path; covered by the same fallback timer code path |
 | Dynamically created/recreated dialogs | Tested explicitly with `document.createElement` + append pattern |
 | Focus restoration on close regressed | Existing "restores focus to the element that was active when the dialog opened" test continues to pass |
+| Stale `keydown` listener on remount | `disconnectedCallback` now calls `focusTrap.disconnect()` before clearing the reference |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "@aurodesignsystem/auro-cli": "^3.6.0",
         "@aurodesignsystem/auro-config": "^1.3.1",
         "@aurodesignsystem/auro-icon": "^9.2.0",
-        "@aurodesignsystem/auro-library": "^5.12.3",
-        "@aurodesignsystem/design-tokens": "^8.18.0",
-        "@aurodesignsystem/webcorestylesheets": "^11.0.0",
+        "@aurodesignsystem/auro-library": "^5.13.2",
+        "@aurodesignsystem/design-tokens": "^9.3.2",
+        "@aurodesignsystem/webcorestylesheets": "^11.1.3",
         "husky": "^9.1.7"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.12.3",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.12.3.tgz",
-      "integrity": "sha512-SYOZWOVg2w9Yb8DMdOATgarE1mUyA48GshB0Slc8imXhjoTs0uuy00Pmujjq/l9WL/sdA5KzeFQFEk/EtcblQA==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.13.2.tgz",
+      "integrity": "sha512-1+O8licSRED9aFjTMCcQM3Wq0qrEXycdHnpkaRRBtmnKQ9RIfddHjFQQicbKVobbTrNsh7TMpdehqaKRcmvXZQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.18.0.tgz",
-      "integrity": "sha512-dulw0o7rA/iqV4eyRElDctBcxonguTWqRy9qGQKcAtU6HPhccGqwCzPv7kINDqO/FJp6mWLb7zQ5/3iJ1HZf8w==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-9.3.2.tgz",
+      "integrity": "sha512-giNceftd7G54ULyF51ZF/m0Wgb/DQVoxAdaS7+ve9/MPxCv6PwgsmzDisyzRR//cJzWiiMY/htOqq/lsMYs78g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -498,14 +498,14 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-11.0.0.tgz",
-      "integrity": "sha512-Z6AcSAJO+wd+QakLVqrgx+pKaynpF6s63ea3DW3YOP5pREUEyI1trJwf77hI/9VsnUww2NuL3uTkDQMPEilOSw==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-11.1.3.tgz",
+      "integrity": "sha512-/ylb8wamSUzPfVwHb6w9R31mVMWmsHTglXy1eqOa4NHIN1v8MK11rxxPRSFI/tCVVnoglZ3aTGO/RaVPPyLX7Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "^8.18.0",
+        "@aurodesignsystem/design-tokens": "^8.19.0",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -513,6 +513,16 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
+      }
+    },
+    "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.21.2.tgz",
+      "integrity": "sha512-WkKVKRmn23j2zwstcZvuuouCGVfd+lhfl6meH9QwrpbqUoRx5KMj+nb+Nm3XqiyjIipwgHRTWFss00tczq29aQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.14.0 || >= 24.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -14851,25 +14861,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "dev": true,
@@ -15431,15 +15422,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
       "dev": true,
@@ -15448,11 +15430,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -15575,14 +15552,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/npm/node_modules/ini": {
@@ -16297,18 +16266,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -16348,14 +16305,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -16442,24 +16391,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
@@ -16613,51 +16544,11 @@
         "node": ">=18.17"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@aurodesignsystem/auro-cli": "^3.6.0",
         "@aurodesignsystem/auro-config": "^1.3.1",
         "@aurodesignsystem/auro-icon": "^9.2.0",
-        "@aurodesignsystem/auro-library": "^5.13.2",
+        "@aurodesignsystem/auro-library": "^5.13.3",
         "@aurodesignsystem/design-tokens": "^9.3.2",
         "@aurodesignsystem/webcorestylesheets": "^11.1.3",
         "husky": "^9.1.7"
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.13.2.tgz",
-      "integrity": "sha512-1+O8licSRED9aFjTMCcQM3Wq0qrEXycdHnpkaRRBtmnKQ9RIfddHjFQQicbKVobbTrNsh7TMpdehqaKRcmvXZQ==",
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.13.3.tgz",
+      "integrity": "sha512-khXdAxcEULJ9ZrrL9yzv7ndJHZBqy97oLX1hwx1o/RwPZAUwncZWlgs8l571ogd4VffmuVrTlHgRbIcb4jPktQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@aurodesignsystem/auro-cli": "^3.6.0",
     "@aurodesignsystem/auro-config": "^1.3.1",
     "@aurodesignsystem/auro-icon": "^9.2.0",
-    "@aurodesignsystem/auro-library": "^5.13.2",
+    "@aurodesignsystem/auro-library": "^5.13.3",
     "@aurodesignsystem/design-tokens": "^9.3.2",
     "@aurodesignsystem/webcorestylesheets": "^11.1.3",
     "husky": "^9.1.7"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "@aurodesignsystem/auro-cli": "^3.6.0",
     "@aurodesignsystem/auro-config": "^1.3.1",
     "@aurodesignsystem/auro-icon": "^9.2.0",
-    "@aurodesignsystem/auro-library": "^5.12.3",
-    "@aurodesignsystem/design-tokens": "^8.18.0",
-    "@aurodesignsystem/webcorestylesheets": "^11.0.0",
+    "@aurodesignsystem/auro-library": "^5.13.2",
+    "@aurodesignsystem/design-tokens": "^9.3.2",
+    "@aurodesignsystem/webcorestylesheets": "^11.1.3",
     "husky": "^9.1.7"
   },
   "browserslist": [

--- a/src/componentBase.js
+++ b/src/componentBase.js
@@ -273,6 +273,15 @@ export default class ComponentBase extends LitElement {
       clearTimeout(this._hidePopoverTimerId);
       this._hidePopoverTimerId = undefined;
     }
+    if (this._focusFallbackTimerId) {
+      clearTimeout(this._focusFallbackTimerId);
+      this._focusFallbackTimerId = undefined;
+    }
+    if (this.focusTrap) {
+      this.focusTrap.disconnect();
+      this.focusTrap = undefined;
+    }
+    this._focusTrapActivated = false;
     this.floater.disconnect();
   }
 
@@ -294,17 +303,44 @@ export default class ComponentBase extends LitElement {
       this.dialog.showPopover();
     }
 
+    if (this._focusFallbackTimerId) {
+      clearTimeout(this._focusFallbackTimerId);
+      this._focusFallbackTimerId = undefined;
+    }
+    if (this.focusTrap) {
+      this.focusTrap.disconnect();
+    }
+
     this.focusTrap = new FocusTrap(this.dialog);
-    // Focus is moved after the CSS open animation completes (see onDialogTransitionEnd).
+    this._focusTrapActivated = false;
+
+    // Fallback: if transitionend never fires (dialog mounted already-open,
+    // reduced motion, or interrupted transition), engage the focus trap after
+    // the transition duration elapses. 350ms = CSS open transition (300ms in
+    // style.scss) + 50ms buffer.
+    this._focusFallbackTimerId = setTimeout(() => {
+      this._focusFallbackTimerId = undefined;
+      if (this.isPopoverVisible && this.focusTrap && !this._focusTrapActivated) {
+        this.focusTrap.focusFirstElement();
+        this._focusTrapActivated = true;
+      }
+    }, 350);
   }
 
   /**
-   * set the focus on the first element after opening transition effect is complete.
+   * Cancels the focus-trap fallback timer (if pending) and moves focus into
+   * the dialog once the open CSS transition completes. No-ops when the
+   * fallback timer already activated the trap (_focusTrapActivated === true).
    * @private
    */
   onDialogTransitionEnd() {
-    if (this.isPopoverVisible && this.focusTrap) {
+    if (this._focusFallbackTimerId) {
+      clearTimeout(this._focusFallbackTimerId);
+      this._focusFallbackTimerId = undefined;
+    }
+    if (this.isPopoverVisible && this.focusTrap && !this._focusTrapActivated) {
       this.focusTrap.focusFirstElement();
+      this._focusTrapActivated = true;
     }
   }
 
@@ -313,6 +349,12 @@ export default class ComponentBase extends LitElement {
    * @returns {void}
    */
   closeDialog() {
+    if (this._focusFallbackTimerId) {
+      clearTimeout(this._focusFallbackTimerId);
+      this._focusFallbackTimerId = undefined;
+    }
+    this._focusTrapActivated = false;
+
     if (this.focusTrap) {
       this.focusTrap.disconnect();
       this.focusTrap = undefined;

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -1,8 +1,20 @@
 import { expect, fixture, html, oneEvent, waitUntil } from "@open-wc/testing";
+import { setViewport, sendKeys } from "@web/test-runner-commands";
 
 import "../src/registered.js";
 
-describe("auro-dialog", () => {
+/**
+ * Runs the full dialog test suite for a given viewport.
+ * @param {boolean} mobileView - Whether tests should run in a narrow mobile viewport.
+ * @returns {void}
+ */
+function runFullTest(mobileView) {
+  before(async () => {
+    await setViewport(
+      mobileView ? { width: 300, height: 800 } : { width: 900, height: 800 },
+    );
+  });
+
   it("auro-dialog is accessible", async () => {
     const el = await fixture(html`
       <auro-dialog open="true">
@@ -359,6 +371,213 @@ describe("auro-dialog", () => {
     await el.updateComplete;
     expect(el.open).to.be.false;
   });
+
+  // --- focus trap on open (AB#1543191) ---
+
+  it("moves focus into dialog after the open transition fires", async () => {
+    const el = await fixture(html`<auro-dialog></auro-dialog>`);
+    el.show();
+    await el.updateComplete;
+
+    await waitUntil(
+      () => !!el.shadowRoot.activeElement,
+      "Focus did not move into dialog after transitionend",
+      { timeout: 1000 }
+    );
+  });
+
+  it("moves focus into dialog when mounted already-open (no transitionend fires)", async () => {
+    const el = await fixture(html`<auro-dialog open></auro-dialog>`);
+
+    await waitUntil(
+      () => !!el.shadowRoot.activeElement,
+      "Focus did not move into dialog via fallback timer",
+      { timeout: 600 }
+    );
+  });
+
+  it("moves focus into a dynamically-created dialog that is already open", async () => {
+    const el = document.createElement("auro-dialog");
+    el.setAttribute("open", "");
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    await waitUntil(
+      () => !!el.shadowRoot.activeElement,
+      "Focus did not move into dynamically-created already-open dialog",
+      { timeout: 600 }
+    );
+
+    el.hide();
+    await el.updateComplete;
+    document.body.removeChild(el);
+  });
+
+  it("does not double-focus when transitionend fires before the fallback timer", async () => {
+    const el = await fixture(html`<auro-dialog></auro-dialog>`);
+    el.show();
+    await el.updateComplete;
+
+    const wrapper = el.shadowRoot.querySelector(".dialog");
+    wrapper.dispatchEvent(new Event("transitionend", { bubbles: false }));
+
+    expect(el._focusTrapActivated).to.be.true;
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(el.focusTrap).to.exist;
+
+    el.hide();
+    await el.updateComplete;
+  });
+
+  it("cancels the fallback timer when dialog is closed before 350ms elapses", async () => {
+    const el = await fixture(html`<auro-dialog></auro-dialog>`);
+    el.show();
+    await el.updateComplete;
+
+    expect(el._focusFallbackTimerId).to.exist;
+    el.hide();
+    await el.updateComplete;
+
+    expect(el._focusFallbackTimerId).to.be.undefined;
+    expect(el._focusTrapActivated).to.be.false;
+
+    // Timer must not fire after close — focusTrap should be torn down
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(el.focusTrap).to.be.undefined;
+  });
+
+  it("rapid re-open disconnects the previous focusTrap before creating a new one", async () => {
+    const el = await fixture(html`<auro-dialog></auro-dialog>`);
+    el.show();
+    await el.updateComplete;
+
+    const firstTrap = el.focusTrap;
+    let firstTrapDisconnected = false;
+    const originalDisconnect = firstTrap.disconnect.bind(firstTrap);
+    firstTrap.disconnect = () => {
+      firstTrapDisconnected = true;
+      originalDisconnect();
+    };
+
+    // Re-open without closing — the previous focusTrap must be disconnected.
+    el.show();
+    await el.updateComplete;
+
+    expect(firstTrapDisconnected).to.be.true;
+    expect(el.focusTrap).to.exist;
+    expect(el.focusTrap).to.not.equal(firstTrap);
+
+    el.hide();
+    await el.updateComplete;
+  });
+
+  it("disconnectedCallback clears the fallback timer while dialog is open", async () => {
+    const el = document.createElement("auro-dialog");
+    document.body.appendChild(el);
+    await el.updateComplete;
+    el.show();
+    await el.updateComplete;
+
+    expect(el._focusFallbackTimerId).to.exist;
+
+    // Call the lifecycle hook directly to test cleanup without removing an
+    // active popover from the DOM (which crashes headless Chrome).
+    el.disconnectedCallback();
+
+    expect(el._focusFallbackTimerId).to.be.undefined;
+    expect(el.focusTrap).to.be.undefined;
+    expect(el._focusTrapActivated).to.be.false;
+
+    el.hide();
+    await el.updateComplete;
+    document.body.removeChild(el);
+  });
+
+  it("Tab key keeps focus within the open dialog", async () => {
+    const el = await fixture(html`
+      <auro-dialog open>
+        <button id="btn1" slot="content">One</button>
+        <button id="btn2" slot="footer">Two</button>
+      </auro-dialog>
+    `);
+
+    await waitUntil(
+      () => el._focusTrapActivated === true,
+      "Focus trap was not activated",
+      { timeout: 600 }
+    );
+
+    await sendKeys({ press: "Tab" });
+
+    expect(el.contains(document.activeElement)).to.be.true;
+  });
+
+  it("focus is trapped in a dynamically-created already-open dialog when Tab is pressed (AB#1543191)", async () => {
+    // Regression: consumers who destroy/recreate the dialog on the same event
+    // that opens it (e.g. flight-search refundable-upsell) mount it already in
+    // the open state, so no closed->open CSS transition fires and transitionend
+    // never runs. The fallback timer must engage the focus trap so Tab cannot
+    // reach page content behind the dialog.
+    const el = document.createElement("auro-dialog");
+    el.setAttribute("open", "");
+    const btn1 = document.createElement("button");
+    btn1.id = "btn1";
+    btn1.slot = "content";
+    btn1.textContent = "One";
+    const btn2 = document.createElement("button");
+    btn2.id = "btn2";
+    btn2.slot = "footer";
+    btn2.textContent = "Two";
+    el.appendChild(btn1);
+    el.appendChild(btn2);
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    await waitUntil(
+      () => el._focusTrapActivated === true,
+      "Focus trap was not activated for dynamically-created already-open dialog",
+      { timeout: 600 }
+    );
+
+    await sendKeys({ press: "Tab" });
+
+    expect(el.contains(document.activeElement)).to.be.true;
+
+    el.hide();
+    await el.updateComplete;
+    document.body.removeChild(el);
+  });
+
+  it("Shift+Tab keeps focus within the open dialog", async () => {
+    const el = await fixture(html`
+      <auro-dialog open>
+        <button id="btn1" slot="content">One</button>
+        <button id="btn2" slot="footer">Two</button>
+      </auro-dialog>
+    `);
+
+    await waitUntil(
+      () => el._focusTrapActivated === true,
+      "Focus trap was not activated",
+      { timeout: 600 }
+    );
+
+    await sendKeys({ down: "Shift" });
+    await sendKeys({ press: "Tab" });
+    await sendKeys({ up: "Shift" });
+
+    expect(el.contains(document.activeElement)).to.be.true;
+  });
+}
+
+describe("auro-dialog", () => {
+  runFullTest(false);
+});
+
+describe("auro-dialog in mobile viewport", () => {
+  runFullTest(true);
 });
 
 function _sleep(ms) {

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -161,7 +161,7 @@ function runFullTest(mobileView) {
     expect(el.open).to.be.true;
   });
 
-it("show() opens the dialog and hide() closes it", async () => {
+  it("show() opens the dialog and hide() closes it", async () => {
     const el = await fixture(html`<auro-dialog></auro-dialog>`);
 
     expect(el.open).to.be.false;

--- a/test/auro-dialog.test.js
+++ b/test/auro-dialog.test.js
@@ -149,7 +149,19 @@ function runFullTest(mobileView) {
     expect(el.open).to.be.true;
   });
 
-  it("show() opens the dialog and hide() closes it", async () => {
+  it("modal dialog does not close when Escape keydown is dispatched (AB#1613688)", async () => {
+    const el = await fixture(html`<auro-dialog modal></auro-dialog>`);
+    el.show();
+    await el.updateComplete;
+    expect(el.open).to.be.true;
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    await el.updateComplete;
+
+    expect(el.open).to.be.true;
+  });
+
+it("show() opens the dialog and hide() closes it", async () => {
     const el = await fixture(html`<auro-dialog></auro-dialog>`);
 
     expect(el.open).to.be.false;


### PR DESCRIPTION
[AB#1543191](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1543191), [AB#1613688](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1613688)

<!-- claude-code-review:pm-exec-summary:start -->
## Executive Summary

`auro-dialog` focus trap silently skipped for dialogs mounted already-open because `transitionend` never fires when there is no CSS transition to animate. Added a 350ms fallback timer so focus is always captured regardless of transition presence. Fixed a secondary listener-leak where `disconnectedCallback` did not call `focusTrap.disconnect()`, allowing stale `keydown` listeners to accumulate on remount.

<sub><i>Synced from <code>docs/post-mortem/1543191.md</code> by the code-review skill.</i></sub>
<!-- claude-code-review:pm-exec-summary:end -->

Dialogs mounted already-open (e.g. destroyed/recreated on the same open event) never emit a closed→open CSS transition, so transitionend never runs and the focus trap was silently skipped. Add a 350ms fallback timer in openDialog() that activates the focus trap if transitionend has not already done so; clear the timer in closeDialog(), disconnectedCallback(), and at the top of openDialog() to prevent double-activation or leaks on rapid open/close cycles. Add _focusTrapActivated flag to prevent double-focus when both paths race. Bump auro-library, design-tokens, and webcorestylesheets. Add focused test coverage for all failure modes across desktop and mobile viewports.

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-dialog/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure auro-dialog always engages its focus trap when opened, even if no CSS transition occurs, and validate behavior across desktop and mobile viewports.

Bug Fixes:
- Fix focus trap not activating when dialogs are mounted already open or when the open transition does not fire, preventing keyboard focus from escaping to page content.

Enhancements:
- Add a timer-based fallback and internal state flag to reliably move focus into the dialog without double-activation, and clean up focus-related timers on close and disconnect.

Build:
- Update design system dependencies (auro-library, design-tokens, webcorestylesheets) to newer versions.

Documentation:
- Add a post-mortem document explaining the accessibility bug, root cause, fix, test coverage, and lessons learned for [AB#1543191](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1543191).

Tests:
- Expand auro-dialog tests with keyboard-interaction and dynamically-created dialog scenarios, and run the full suite in both desktop and mobile viewports to cover all focus trap failure modes.
